### PR TITLE
Improvements to Chart Types

### DIFF
--- a/etc/paramanifest.api.md
+++ b/etc/paramanifest.api.md
@@ -14,10 +14,16 @@ export type AllSeriesData = Record<string, Datapoint[]>;
 export type AllSeriesDataXY = Record<string, XyPoint[]>;
 
 // @public (undocumented)
+export const CHART_FAMILY_MAP: Record<ChartType, ChartTypeFamily>;
+
+// @public (undocumented)
 export function chartDataIsOrdered(data: AllSeriesData): boolean;
 
 // @public (undocumented)
 export type ChartType = Manifest['datasets'][number]['type'];
+
+// @public (undocumented)
+export type ChartTypeFamily = 'line' | 'bar' | 'pastry' | 'scatter';
 
 // @public (undocumented)
 export function collectXs(data: Datapoint[]): Set<string>;
@@ -80,6 +86,21 @@ export interface Facet {
 }
 
 // @public (undocumented)
+export function isBarType(chartType: ChartType): boolean;
+
+// @public (undocumented)
+export function isLineType(chartType: ChartType): boolean;
+
+// @public (undocumented)
+export function isPastryType(chartType: ChartType): boolean;
+
+// @public (undocumented)
+export function isPlaneType(chartType: ChartType): boolean;
+
+// @public (undocumented)
+export function isScatterType(chartType: ChartType): boolean;
+
+// @public (undocumented)
 export class Jimerator {
     constructor(_manifest: Manifest, externalData?: AllSeriesData);
     // Warning: (ae-forgotten-export) The symbol "Jim" needs to be exported by the entry point index.d.ts
@@ -101,6 +122,9 @@ export class ManifestValidator {
     fullValidate(json: Json): Promise<OutputUnit>;
     validate(json: Json): Promise<ValidateOutput>;
 }
+
+// @public (undocumented)
+export const PLANE_CHART_FAMILIES: ChartTypeFamily[];
 
 // @public
 export interface SeriesManifest {

--- a/etc/paramanifest.api.md
+++ b/etc/paramanifest.api.md
@@ -47,10 +47,11 @@ export interface Dataset {
         [k: string]: Facet;
     };
     series: SeriesManifest[];
+    seriesRelations?: "stacked" | "groups";
     // (undocumented)
     settings?: Settings;
     title: string;
-    type: "line" | "column" | "bar" | "scatter" | "lollipop" | "stepline" | "pie" | "donut";
+    type: "line" | "stepline" | "bar" | "column" | "lollipop" | "histogram" | "scatter" | "pie" | "donut";
 }
 
 // @public (undocumented)

--- a/lib/chart_types.ts
+++ b/lib/chart_types.ts
@@ -1,0 +1,63 @@
+/* ParaManifest: Chart Types
+Copyright (C) 2025 Fizz Studios
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
+
+// Imports
+
+import { Manifest } from "./manifest";
+
+// Types
+
+export type ChartType = Manifest['datasets'][number]['type'];
+
+export type ChartTypeFamily = 'line' | 'bar' | 'pastry' | 'scatter';
+
+// Constants
+
+export const CHART_FAMILY_MAP: Record<ChartType, ChartTypeFamily> = {
+  'line': 'line',
+  'stepline': 'line',
+  'bar': 'bar',
+  'column': 'bar',
+  'lollipop': 'bar',
+  'histogram': 'bar',
+  'scatter': 'scatter',
+  'pie': 'pastry',
+  'donut': 'pastry'
+}
+
+export const PLANE_CHART_FAMILIES: ChartTypeFamily[] = ['line', 'bar', 'scatter'];
+
+// Functions
+
+export function isPlaneType(chartType: ChartType): boolean {
+  return PLANE_CHART_FAMILIES.includes(CHART_FAMILY_MAP[chartType]);
+}
+
+export function isLineType(chartType: ChartType): boolean {
+  return CHART_FAMILY_MAP[chartType] === 'line';
+}
+
+export function isBarType(chartType: ChartType): boolean {
+  return CHART_FAMILY_MAP[chartType] === 'bar';
+}
+
+export function isScatterType(chartType: ChartType): boolean {
+  return CHART_FAMILY_MAP[chartType] === 'scatter';
+}
+
+export function isPastryType(chartType: ChartType): boolean {
+  return CHART_FAMILY_MAP[chartType] === 'pastry';
+}

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import { Datapoint, Manifest } from "./manifest";
 
-// Types
+//  Types
 
 /**
  * A datapoint on the graph.
@@ -34,7 +34,6 @@ export interface XyPoint {
   y: string;
 }
 
-export type ChartType = Manifest['datasets'][number]['type'];
 export type Datatype = Manifest['datasets'][number]['facets']['x']['datatype'];
 export type AllSeriesDataXY = Record<string, XyPoint[]>;
 export type AllSeriesData = Record<string, Datapoint[]>;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,4 +22,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 export * from './manifest';
 export * from './validator';
 export * from './helpers';
+export * from './chart_types';
 export { Jimerator } from './jim';

--- a/lib/jim.ts
+++ b/lib/jim.ts
@@ -14,7 +14,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
-import { AllSeriesData, chartDataIsOrdered, ChartType, collectXs, dataFromManifest } from "./helpers";
+import { ChartType } from "./chart_types";
+import { AllSeriesData, chartDataIsOrdered, collectXs, dataFromManifest } from "./helpers";
 import { Datapoint, Manifest, Dataset as ManifestDataset } from "./manifest";
 
 export interface Jim {
@@ -63,6 +64,7 @@ const CHART_TYPE_MAP: Record<ChartType, SeriesType> = {
   bar: 'column',
   column: 'column',
   lollipop: 'column',
+  histogram: 'column',
   line: 'line',
   stepline: 'line',
   scatter: 'other',

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -26,7 +26,7 @@ export interface Dataset {
   /**
    * The type of the chart, such as 'line' or 'column'.
    */
-  type: "line" | "column" | "bar" | "scatter" | "lollipop" | "stepline" | "pie" | "donut";
+  type: "line" | "stepline" | "bar" | "column" | "lollipop" | "histogram" | "scatter" | "pie" | "donut";
   /**
    * The title of the chart.
    */
@@ -42,6 +42,10 @@ export interface Dataset {
    * Metadata, and possibly inline data, describing the series of the chart.
    */
   series: SeriesManifest[];
+  /**
+   * How series are related to each other in multi-series bar family charts. Defaults to 'stacked'.
+   */
+  seriesRelations?: "stacked" | "groups";
   data: Data;
   settings?: Settings;
 }

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -49,6 +49,10 @@
           },
           "uniqueItems": true
         },
+        "seriesRelations": {
+          "description": "How series are related to each other in multi-series bar family charts. Defaults to 'stacked'.",
+          "enum": ["stacked", "groups"]
+        },
         "data": {
           "description": "The source for the data for this dataset.",
           "$ref": "#/$defs/data"

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -23,7 +23,7 @@
       "properties": {
         "type": {
           "description": "The type of the chart, such as 'line' or 'column'.",
-          "enum": ["line", "column", "bar", "scatter", "lollipop", "stepline", "pie", "donut"]
+          "enum": ["line", "stepline", "bar", "column", "lollipop", "histogram", "scatter", "pie", "donut"]
         },
         "title": {
           "description": "The title of the chart.",


### PR DESCRIPTION
Adds 'histogram' chart type.

Adds 'seriesRelations' field in manifests. Currently this only records whether multi-series bar family charts are stacked or grouped, but it will be expanded for series hierarchies later. 

Adds functions to determine the family of a chart type.