### PR TITLE
Manifest Changes and Additions

### DIFF
--- a/etc/paramanifest.api.md
+++ b/etc/paramanifest.api.md
@@ -62,6 +62,7 @@ export interface Dataset {
     seriesRelations?: "stacked" | "grouped";
     // (undocumented)
     settings?: Settings;
+    subtitle?: string;
     title: string;
     type: "line" | "stepline" | "bar" | "column" | "lollipop" | "histogram" | "scatter" | "heatmap" | "pie" | "donut" | "graph";
 }
@@ -144,7 +145,7 @@ export interface SeriesManifest {
     label?: string;
     records?: DatapointManifest[];
     // (undocumented)
-    theme: Theme1;
+    theme?: Theme1;
 }
 
 // @public
@@ -152,6 +153,11 @@ export interface Settings {
     "sonification.isEnabled"?: boolean;
     aspectRatio?: number;
 }
+
+// Warning: (ae-internal-missing-underscore) The name "strToId" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function strToId(s: string): string;
 
 // @public
 export interface Theme {

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -79,3 +79,14 @@ export function chartDataIsOrdered(data: AllSeriesData): boolean {
   }
   return true;
 }
+
+/**
+ * Takes a string and normalizes it, stripping it of any non-alphanum characters and replacing its 
+ *   whitespaces with underscores, so that can can serve as a DOM id.
+ * @param {string} s A string, which may have spaces, punctuation, or other non-alphanum characters.
+ * @returns {string} The unique string, stripped of all non-alphanum characters, to be used as an id.
+ * @internal
+ */
+export function strToId(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, '_').replace(/[^\w-]+/g, '_');
+}

--- a/lib/jim.ts
+++ b/lib/jim.ts
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 // Imports
 
 import { ChartType } from "./chart_types";
-import { AllSeriesData, chartDataIsOrdered, collectXs, dataFromManifest } from "./helpers";
+import { AllSeriesData, chartDataIsOrdered, collectXs, dataFromManifest, strToId } from "./helpers";
 import { DatapointManifest, Manifest, Dataset as ManifestDataset } from "./manifest";
 
 // Types
@@ -89,10 +89,6 @@ export class JimError extends Error {
   }
 }
 
-function sanitized(input: string): string {
-  return input.replaceAll('.', '_');
-}
-
 // * Main Class *
 
 export class Jimerator {
@@ -125,7 +121,7 @@ export class Jimerator {
     this._seriesKeys.forEach((key, seriesIndex) => {
       xs.forEach((x, pointIndex) => {
         selectors[`datapoint${datapointIndex}`] = {
-          "dom": `#datapoint-${sanitized(x)}_${key}`,
+          "dom": `#datapoint-${strToId(x)}_${key}`,
           "json": [
             `$.datasets[0].series[${seriesIndex}].name`,
             `$.datasets[0].series[${seriesIndex}].records[${pointIndex}].*`
@@ -140,8 +136,8 @@ export class Jimerator {
     let datapointIndex = 1;
     Object.keys(this._data).forEach((key, seriesIndex) => {
       this._data[key].forEach((datapoint, pointIndex) => {
-        const xSanitized = sanitized(datapoint.x);
-        const ySanitized = sanitized(datapoint.y);
+        const xSanitized = strToId(datapoint.x);
+        const ySanitized = strToId(datapoint.y);
         selectors[`datapoint${datapointIndex}`] = {
           dom: `#datapoint-${xSanitized}_${ySanitized}_${key}`,
           json: [

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -50,6 +50,10 @@ export interface Dataset {
    * The title of the chart.
    */
   title: string;
+  /**
+   * The subtitle of the chart.
+   */
+  subtitle?: string;
   chartTheme?: Theme;
   /**
    * Metadata describing each facet of the chart which represents some dimension of the data.
@@ -168,7 +172,7 @@ export interface SeriesManifest {
    * The text label for the series, which may be abbreviated or expanded from the series key. Defaults to key.
    */
   label?: string;
-  theme: Theme1;
+  theme?: Theme1;
   /**
    * The datapoints of this series represented inline.
    */

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -137,7 +137,7 @@
           }
         }
       },
-      "required": ["key", "theme"],
+      "required": ["key"],
       "additionalProperties": false
     },
     "theme": {

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -29,6 +29,10 @@
           "description": "The title of the chart.",
           "$ref": "#/$defs/name"
         },
+        "subtitle": {
+          "description": "The subtitle of the chart.",
+          "$ref": "#/$defs/name"
+        },
         "chartTheme": {
           "description": "What quantities the line chart displays overall. Defaults to the theme of the single series ONLY in single series charts.",
           "$ref": "#/$defs/theme"


### PR DESCRIPTION
Adds a chart subtitle field to manifests. Closes #19

Moves `strToId` here from ParaModel. Closes #18

Makes series.theme an optional field.