### PR TITLE
Allow unspecified settings in manifest, start adding axis settings

### DIFF
--- a/etc/paramanifest.api.md
+++ b/etc/paramanifest.api.md
@@ -13,6 +13,22 @@ export type AllSeriesData = Record<string, DatapointManifest[]>;
 // @public (undocumented)
 export type AllSeriesDataXY = Record<string, XyPoint[]>;
 
+// @public
+export interface AxisSettings {
+    // (undocumented)
+    [k: string]: unknown;
+    maxValue?: number | "unset";
+    minValue?: number | "unset";
+}
+
+// @public
+export interface AxisSettings1 {
+    // (undocumented)
+    [k: string]: unknown;
+    maxValue?: number | "unset";
+    minValue?: number | "unset";
+}
+
 // @public (undocumented)
 export type BaseKind = Theme['baseKind'];
 
@@ -157,8 +173,18 @@ export interface SeriesManifest {
 
 // @public
 export interface Settings {
-    "sonification.isEnabled"?: boolean;
+    // (undocumented)
+    [k: string]: unknown;
     aspectRatio?: number;
+    axis?: {
+        x?: AxisSettings;
+        y?: AxisSettings1;
+        [k: string]: unknown;
+    };
+    sonification?: {
+        isSoniEnabled?: boolean;
+        [k: string]: unknown;
+    };
 }
 
 // Warning: (ae-internal-missing-underscore) The name "strToId" should be prefixed with an underscore because the declaration is marked as @internal

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -225,11 +225,54 @@ export interface DatapointManifest {
  */
 export interface Settings {
   /**
-   * Whether sonification is enabled for this chart. Defaults to true.
+   * Sonification Settings
    */
-  "sonification.isEnabled"?: boolean;
+  sonification?: {
+    /**
+     * Whether sonification is enabled for this chart. Defaults to true.
+     */
+    isSoniEnabled?: boolean;
+    [k: string]: unknown;
+  };
   /**
    * The ratio of the height to the width of the chart on the screen (i.e. x-axis size / y-axis size). Defaults to 1 (i.e. a square chart).
    */
   aspectRatio?: number;
+  /**
+   * Settings for each Axis
+   */
+  axis?: {
+    x?: AxisSettings;
+    y?: AxisSettings1;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+/**
+ * X Axis Settings
+ */
+export interface AxisSettings {
+  /**
+   * The minimum value of the axis.
+   */
+  minValue?: number | "unset";
+  /**
+   * The maximum value of the axis.
+   */
+  maxValue?: number | "unset";
+  [k: string]: unknown;
+}
+/**
+ * Y Axis Settings
+ */
+export interface AxisSettings1 {
+  /**
+   * The minimum value of the axis.
+   */
+  minValue?: number | "unset";
+  /**
+   * The maximum value of the axis.
+   */
+  maxValue?: number | "unset";
+  [k: string]: unknown;
 }

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -226,17 +226,35 @@
       "description": "The settings needed to present a chart in ParaCharts.",
       "type": "object",
       "properties": {
-        "sonification.isEnabled": {
-          "description": "Whether sonification is enabled for this chart. Defaults to true.",
-          "type": "boolean"
+        "sonification": {
+          "description": "Sonification Settings",
+          "type": "object",
+          "properties": {
+            "isSoniEnabled": {
+              "description": "Whether sonification is enabled for this chart. Defaults to true.",
+              "type": "boolean"
+            }
+          }
         },
         "aspectRatio": {
           "description": "The ratio of the height to the width of the chart on the screen (i.e. x-axis size / y-axis size). Defaults to 1 (i.e. a square chart).",
           "type": "number"
+        },
+        "axis": {
+          "description": "Settings for each Axis",
+          "type": "object",
+          "properties": {
+            "x": {
+              "description": "X Axis Settings",
+              "$ref": "#/$defs/axisSettings"
+            },
+            "y": {
+              "description": "Y Axis Settings",
+              "$ref": "#/$defs/axisSettings"
+            }
+          }
         }
-      },
-      "required": [ ],
-      "additionalProperties": false
+      }
     },
     "name": {
       "description": "The name of something, as a non-empty string.",
@@ -291,6 +309,38 @@
       "required": [ "type" ],
       "additionalProperties": false,
       "$comment": "Additional validation: The other properties should be only those relevant to the type."
+    },
+    "axisSettings": {
+      "description": "Settings for a particular Axis",
+      "type": "object",
+      "properties": {
+        "minValue": {
+          "description": "The minimum value of the axis.",
+          "$ref": "#/$defs/axisExtremeValue"
+        },
+        "maxValue": {
+          "description": "The maximum value of the axis.",
+          "$ref": "#/$defs/axisExtremeValue"
+        }
+      }
+    },
+    "axisExtremeValue": {
+      "description": "Settings for an extreme of a particular Axis",
+      "oneOf": [
+        { "$ref": "#/$defs/number" },
+        { "$ref": "#/$defs/constUnset" }
+      ],
+      "tsType": "number | 'unset'"
+    },
+    "number": {
+      "description": "A number.",
+      "type": "number",
+      "$comment": "`number` is necessary for `axisExtremeValue` to avoid TypeScript type inference errors."
+    },
+    "constUnset": {
+      "description": "The constant 'unset'.",
+      "const": "unset",
+      "$comment": "`constUnset` is necessary for `axisExtremeValue` to avoid TypeScript type inference errors."
     }
   }
 }


### PR DESCRIPTION
Allows unspecified settings in manifest. This will allow all settings to be added to a manifest until #25 is addressed.

Also starts to add some of the actual axis settings.