### PR TITLE
Improve strToId

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -90,5 +90,5 @@ export function chartDataIsOrdered(data: AllSeriesData): boolean {
  * @internal
  */
 export function strToId(s: string): string {
-  return s.replace(/\s+/g, '_').replace(/\W/g, '_').toLowerCase();
-}
+  return s.replace(/\W+/g, '_').toLowerCase();
+} //.replace(/\s+/g, '_')

--- a/test/normalizeid.test.ts
+++ b/test/normalizeid.test.ts
@@ -2,5 +2,5 @@ import { expect, test } from 'vitest';
 import { strToId } from '../lib';
 
 test('strToId', () => {
-  expect(strToId('  aB$)\t  Cd$$ ')).toBe('_ab___cd___');
+  expect(strToId('  aB$)\t  Cd$$ ')).toBe('_ab_cd_');
 })


### PR DESCRIPTION
Improves strToId so all non-alphanumeric character substrings are collapsed and replaced with an underscore. See https://github.com/fizzstudio/ParaModel/issues/34 and #27